### PR TITLE
export `Ref.ReferenceURL` and `Ref.ReferencePointer`, add a `Ref.HasOnlyFragment()` method

### DIFF
--- a/reference.go
+++ b/reference.go
@@ -59,8 +59,8 @@ func MustCreateRef(ref string) Ref {
 
 // Ref represents a json reference object
 type Ref struct {
-	referenceURL     *url.URL
-	referencePointer jsonpointer.Pointer
+	ReferenceURL     *url.URL
+	ReferencePointer jsonpointer.Pointer
 
 	HasFullURL      bool
 	HasURLPathOnly  bool
@@ -69,36 +69,50 @@ type Ref struct {
 	HasFullFilePath bool
 }
 
+// HasOnlyFragment returns true if the ReferenceURL has no host and/or path
+func (r *Ref) HasOnlyFragment() bool {
+	if r.ReferenceURL == nil {
+		return false
+	}
+	if r.ReferenceURL.Host != "" {
+		return false
+	}
+	if r.ReferenceURL.Path != "" {
+		return false
+	}
+	return true
+}
+
 // GetURL gets the URL for this reference
 func (r *Ref) GetURL() *url.URL {
-	return r.referenceURL
+	return r.ReferenceURL
 }
 
 // GetPointer gets the json pointer for this reference
 func (r *Ref) GetPointer() *jsonpointer.Pointer {
-	return &r.referencePointer
+	return &r.ReferencePointer
 }
 
 // String returns the best version of the url for this reference
 func (r *Ref) String() string {
 
-	if r.referenceURL != nil {
-		return r.referenceURL.String()
+	if r.ReferenceURL != nil {
+		return r.ReferenceURL.String()
 	}
 
-	if r.HasFragmentOnly {
-		return fragmentRune + r.referencePointer.String()
+	if r.HasOnlyFragment() {
+		return fragmentRune + r.ReferencePointer.String()
 	}
 
-	return r.referencePointer.String()
+	return r.ReferencePointer.String()
 }
 
 // IsRoot returns true if this reference is a root document
 func (r *Ref) IsRoot() bool {
-	return r.referenceURL != nil &&
+	return r.ReferenceURL != nil &&
 		!r.IsCanonical() &&
 		!r.HasURLPathOnly &&
-		r.referenceURL.Fragment == ""
+		r.ReferenceURL.Fragment == ""
 }
 
 // IsCanonical returns true when this pointer starts with http(s):// or file://
@@ -116,8 +130,8 @@ func (r *Ref) parse(jsonReferenceString string) error {
 
 	internal.NormalizeURL(parsed)
 
-	r.referenceURL = parsed
-	refURL := r.referenceURL
+	r.ReferenceURL = parsed
+	refURL := r.ReferenceURL
 
 	if refURL.Scheme != "" && refURL.Host != "" {
 		r.HasFullURL = true
@@ -133,7 +147,7 @@ func (r *Ref) parse(jsonReferenceString string) error {
 	r.HasFullFilePath = strings.HasPrefix(refURL.Path, "/")
 
 	// invalid json-pointer error means url has no json-pointer fragment. simply ignore error
-	r.referencePointer, _ = jsonpointer.New(refURL.Fragment)
+	r.ReferencePointer, _ = jsonpointer.New(refURL.Fragment)
 
 	return nil
 }

--- a/reference_test.go
+++ b/reference_test.go
@@ -97,16 +97,16 @@ func TestFragmentOnly(t *testing.T) {
 	require.False(t, r1.HasFileScheme)
 	require.Equal(t, "/fragment/only", r1.GetPointer().String())
 
-	p, err := jsonpointer.New(r1.referenceURL.Fragment)
+	p, err := jsonpointer.New(r1.ReferenceURL.Fragment)
 	require.NoError(t, err)
 
 	t.Run("Ref with fragmentOnly", func(t *testing.T) {
-		r2 := Ref{referencePointer: p, HasFragmentOnly: true}
+		r2 := Ref{ReferencePointer: p, HasFragmentOnly: true}
 		assert.Equal(t, in, r2.String())
 	})
 
 	t.Run("Ref without fragmentOnly", func(t *testing.T) {
-		r3 := Ref{referencePointer: p, HasFragmentOnly: false}
+		r3 := Ref{ReferencePointer: p, HasFragmentOnly: false}
 		assert.Equal(t, in[1:], r3.String())
 	})
 }


### PR DESCRIPTION
Ensure we can evaluate the `ReferenceURL` on demand instead of only at `parse()` time